### PR TITLE
출석 체크에 필요한 날짜 조회 추가

### DIFF
--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, Query } from '@nestjs/common';
 import { AppService } from './app.service';
 
 @Controller()
@@ -8,5 +8,14 @@ export class AppController {
   @Get()
   getHello(): string {
     return this.appService.getHello();
+  }
+
+  @Get('/week-search')
+  getWeekDate(
+    @Query('startDate') startDate: string,
+    @Query('endDate') endDate: string,
+    @Query('kind') kind: string,
+  ): object {
+    return this.appService.getWeekDate(startDate, endDate, kind);
   }
 }

--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -5,4 +5,53 @@ export class AppService {
   getHello(): string {
     return 'Hello World!';
   }
+
+  getWeekDate(startDate: string, endDate: string, kind: string) {
+    let weekDate = {};
+    //받은 값
+    const setStart = new Date(startDate);
+    const setEnd = new Date(endDate);
+    //시작일,끝일
+    let weekStartDate = new Date();
+    let weekEndDate = new Date();
+    let year = 0,
+      month = '',
+      day = '',
+      firstStr = '',
+      endStr = '';
+
+    if (kind === 'now') {
+      //현재
+      const nowYear = weekStartDate.getFullYear();
+      const nowMonth = weekStartDate.getMonth() + 1;
+      const nowDay = weekStartDate.getDate();
+      const nowDayOfWeek = weekStartDate.getDay();
+      weekStartDate = new Date(nowYear, nowMonth, nowDay - nowDayOfWeek); //일요일
+      weekEndDate = new Date(nowYear, nowMonth, nowDay + (6 - nowDayOfWeek)); //토요일
+    } else if (kind === 'prev') {
+      //이전
+      weekStartDate.setDate(setStart.getDate() - 7);
+      weekEndDate.setDate(setEnd.getDate() - 7);
+    } else if (kind === 'next') {
+      //다음
+      weekStartDate.setDate(setStart.getDate() + 7);
+      weekEndDate.setDate(setEnd.getDate() + 7);
+    }
+    //시작일 셋팅
+    year = weekStartDate.getFullYear();
+    month = String(weekStartDate.getMonth() + 1).padStart(2, '0');
+    day = String(weekStartDate.getDate()).padStart(2, '0');
+    firstStr = `${year}-${month}-${day}`;
+    //끝일 셋팅
+    year = weekEndDate.getFullYear();
+    month = String(weekEndDate.getMonth() + 1).padStart(2, '0');
+    day = String(weekEndDate.getDate()).padStart(2, '0');
+    endStr = `${year}-${month}-${day}`;
+    weekDate = {
+      startDate: firstStr,
+      endDate: endStr,
+    };
+
+    return weekDate;
+  }
 }

--- a/src/attendance/attendance.module.ts
+++ b/src/attendance/attendance.module.ts
@@ -3,12 +3,14 @@ import { MongooseModule } from '@nestjs/mongoose';
 import { AttendanceController } from './attendance.controller';
 import { AttendanceService } from './attendance.service';
 import { AttendanceSchema } from './schema/attendnace.schema';
+import { AccountModule } from 'src/account/account.module';
 
 @Module({
   imports: [
     MongooseModule.forFeature([
       { name: 'Attendance', schema: AttendanceSchema },
     ]),
+    AccountModule,
   ],
   controllers: [AttendanceController],
   providers: [AttendanceService],

--- a/src/attendance/attendance.service.ts
+++ b/src/attendance/attendance.service.ts
@@ -1,13 +1,18 @@
-import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Attendance } from './schema/attendnace.schema';
-import { CreateAttendanceDto } from './dto/create-attendance.dto';
+import {
+  CreateAttendanceDto,
+  SearchAttendanceDto,
+} from './dto/create-attendance.dto';
 import { Model } from 'mongoose';
+import { AccountService } from 'src/account/account.service';
 
 @Injectable()
 export class AttendanceService {
   constructor(
     @InjectModel(Attendance.name) private attendancetModel: Model<Attendance>,
+    private accountService: AccountService,
   ) {}
 
   //생성
@@ -29,7 +34,9 @@ export class AttendanceService {
   async findAll(
     startDate: string,
     endDate: string,
-  ): Promise<CreateAttendanceDto[]> {
+  ): Promise<Array<SearchAttendanceDto>> {
+    const attendanceArr = [];
+    const accountArr = [];
     //해당되는 날짜 조회 후, 오름차순으로 정렬(날짜)
     const attendance = await this.attendancetModel
       .find({
@@ -37,7 +44,40 @@ export class AttendanceService {
       })
       .sort({ attendance_date: 1 });
 
-    return attendance;
+    // 필요 데이터로 가공
+    // eslint-disable-next-line prettier/prettier
+    for(const item of attendance){
+      const { user_id, attendance_date } = item;
+      //날짜 포맷
+      const year = attendance_date.getFullYear();
+      const month = String(attendance_date.getMonth() + 1).padStart(2, '0');
+      const day = String(attendance_date.getDate()).padStart(2, '0');
+      const attendance = `${year}-${month}-${day}`;
+      if (!accountArr.includes(user_id)) {
+        //없는 경우
+        const account = await this.accountService.getOne(user_id);
+        if (!account) {
+          throw new NotFoundException(`${user_id} ID not found.`);
+        }
+        accountArr.push(user_id);
+        attendanceArr.push({
+          user_id,
+          image_url: account.image_url,
+          attendance_date: attendance,
+          count: 1,
+        });
+      } else {
+        //있는 경우(날짜와 카운트만 추가)
+        for (let i = 0; i < attendanceArr.length; i++) {
+          if (attendanceArr[i].user_id === user_id) {
+            attendanceArr[i].attendance_date += `,${attendance}`;
+            attendanceArr[i].count += 1;
+          }
+        }
+      }
+    }
+
+    return attendanceArr;
   }
 
   //출석일 최대값 조회

--- a/src/attendance/dto/create-attendance.dto.ts
+++ b/src/attendance/dto/create-attendance.dto.ts
@@ -1,3 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
 import { IsNotEmpty, IsString } from 'class-validator';
 
 export class CreateAttendanceDto {
@@ -7,4 +8,9 @@ export class CreateAttendanceDto {
 
   @IsNotEmpty()
   attendance_date: Date;
+}
+
+export class SearchAttendanceDto extends PartialType(CreateAttendanceDto) {
+  image_url: string;
+  count: number;
 }


### PR DESCRIPTION
- 출석 조회 시에 조건 날짜에 해당하는 리스트만 전달했으나, 프론트엔드에서 출력하는 데이터에 맞게 데이터를 가공하여 전달
```
    {
        "user_id": "ije90s",
        "image_url": "https://avatars.githubusercontent.com/u/86638467?v=4", //프로필 이미지
        "attendance_date": "2022-07-03,2022-07-05,2022-07-07,2022-07-08",  //출석일
        "count": 4 //건수
    },
```
- 출석 체크 보여줄 때 **월**로 보여주는 것이 아닌 **한 주**로 보여주기 때문에 특정 주의 시작일, 끝일을 찾는 API 새로 추가
```
{
    "startDate": "2022-08-31", //시작일(일요일)
    "endDate": "2022-09-06" //끝일(토요일)
}
``` 